### PR TITLE
[Feature / PD-420] Adapt Tachimawari Main to Remove Ros Arguments

### DIFF
--- a/launch/tachimawari_launch.py
+++ b/launch/tachimawari_launch.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2024 ICHIRO ITS
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import os
+import socket
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+  hostname = socket.gethostname()
+  config_path = os.path.expanduser(f'~/ros2-ws/configuration/{hostname}/ipm/')
+
+  return LaunchDescription([
+    Node(
+      package='tachimawari',
+      executable='main',
+      name='main',
+      output='screen',
+      arguments=['cm740', config_path],
+      respawn=True,
+      respawn_delay=1
+    )
+  ])

--- a/src/tachimawari_main.cpp
+++ b/src/tachimawari_main.cpp
@@ -29,10 +29,10 @@ int main(int argc, char * argv[])
 {
   auto args = rclcpp::init_and_remove_ros_arguments(argc, argv);
 
-  if (argc < args.size()) {
+  if (args.size() < 2) {
     std::cerr << "Please specify the mode! [sdk / cm740]" << std::endl;
     return 0;
-  } else if (argc < 3) {
+  } else if (args.size() < 3) {
     std::cerr << "Please specify the tf configuration path" << std::endl;
   }
 

--- a/src/tachimawari_main.cpp
+++ b/src/tachimawari_main.cpp
@@ -27,17 +27,17 @@
 
 int main(int argc, char * argv[])
 {
-  rclcpp::init(argc, argv);
+  auto args = rclcpp::init_and_remove_ros_arguments(argc, argv);
 
-  if (argc < 2) {
+  if (argc < args.size()) {
     std::cerr << "Please specify the mode! [sdk / cm740]" << std::endl;
     return 0;
   } else if (argc < 3) {
     std::cerr << "Please specify the tf configuration path" << std::endl;
   }
 
-  std::string mode = argv[1];
-  std::string path = argv[2];
+  std::string mode = args[1];
+  std::string path = args[2];
   std::shared_ptr<tachimawari::control::ControlManager> controller;
 
   if (mode == "sdk") {


### PR DESCRIPTION
## Jira Link: 
https://ichiro-its.atlassian.net/browse/PD-420
## Description

Adjust the main program of tachimawari to remove ros arguments because ros2 launch automatically appends --ros-args argument after all cmd arguments.

## Type of Change

- [ ] Bugfix
- [ ] Enhancement
- [X] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [X] Manual tested.

## Checklist:

- [X] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.